### PR TITLE
Upgrade to node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,6 @@ inputs:
     description: 'Number of commits to keep as backup'
     default: 100
 runs:
-  using: node12
+  using: node16
   main: main.js
   post: post.js


### PR DESCRIPTION
See https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/